### PR TITLE
fix: docker publish

### DIFF
--- a/.github/workflows/momento-proxy-container-publish.yaml
+++ b/.github/workflows/momento-proxy-container-publish.yaml
@@ -1,8 +1,6 @@
 name: Publish Docker Image to DockerHub
 
 on:
-  push:
-    branches: ["momento"]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ COPY . .
 RUN apt-get update
 RUN apt-get install -y cmake
 RUN apt-get install -y clang
-RUN mkdir .cargo
 RUN cargo vendor > .cargo/config
 
 RUN cargo build --release


### PR DESCRIPTION
Docker build was failing with following error.
```console
 => [cargo-build 5/8] RUN apt-get install -y clang                                                                                                                                                                                                      17.5s
 => ERROR [cargo-build 6/8] RUN mkdir .cargo                                                                                                                                                                                                             0.3s
------
 > [cargo-build 6/8] RUN mkdir .cargo:
#14 0.251 mkdir: cannot create directory '.cargo': File exists
------
executor failed running [/bin/sh -c mkdir .cargo]: exit code: 1                                                                                                                                                                                                       
```

This fixes the docker build since `.cargo` directory is checked into the repo root now we don't need to create that directory in Docker build anymore.

Validated this locally with `docker build .` as well. Also moved the docker container publish from on push to manual for now. 