### PR TITLE
feat: adds PING support to momento proxy resp impl

### DIFF
--- a/src/protocol/resp/src/request/ping.rs
+++ b/src/protocol/resp/src/request/ping.rs
@@ -1,0 +1,60 @@
+// Copyright 2022 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use super::*;
+use std::io::{Error, ErrorKind};
+
+#[derive(Debug, PartialEq, Eq)]
+#[allow(clippy::redundant_allocation)]
+pub struct PingRequest {}
+
+impl TryFrom<Message> for PingRequest {
+    type Error = Error;
+
+    fn try_from(other: Message) -> Result<Self, Error> {
+        if let Message::Array(array) = other {
+            if array.inner.is_none() {
+                return Err(Error::new(ErrorKind::Other, "malformed command"));
+            }
+            Ok(Self {})
+        } else {
+            Err(Error::new(ErrorKind::Other, "malformed command"))
+        }
+    }
+}
+
+impl PingRequest {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl From<&PingRequest> for Message {
+    fn from(_: &PingRequest) -> Message {
+        Message::Array(Array {
+            inner: Some(vec![Message::BulkString(BulkString::new(b"Ping"))]),
+        })
+    }
+}
+
+impl Compose for PingRequest {
+    fn compose(&self, buf: &mut dyn BufMut) -> usize {
+        let message = Message::from(self);
+        message.compose(buf)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parser() {
+        let parser = RequestParser::new();
+        assert_eq!(
+            parser.parse(b"PING\r\n").unwrap().into_inner(),
+            Request::Ping(PingRequest::new())
+        );
+    }
+}

--- a/src/proxy/momento/src/frontend.rs
+++ b/src/proxy/momento/src/frontend.rs
@@ -102,6 +102,11 @@ pub(crate) async fn handle_resp_client(
                             break;
                         }
                     }
+                    resp::Request::Ping(_) => {
+                        if resp::ping(&mut socket).await.is_err() {
+                            break;
+                        }
+                    }
                 }
                 buf.advance(consumed);
             }

--- a/src/proxy/momento/src/protocol/resp/mod.rs
+++ b/src/proxy/momento/src/protocol/resp/mod.rs
@@ -5,7 +5,9 @@
 pub use protocol_resp::{Request, RequestParser};
 
 mod get;
+mod ping;
 mod set;
 
 pub use get::*;
+pub use ping::*;
 pub use set::*;

--- a/src/proxy/momento/src/protocol/resp/ping.rs
+++ b/src/proxy/momento/src/protocol/resp/ping.rs
@@ -1,0 +1,23 @@
+// Copyright 2022 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use crate::Error;
+use net::TCP_SEND_BYTE;
+use session::{SESSION_SEND, SESSION_SEND_BYTE, SESSION_SEND_EX};
+use tokio::io::AsyncWriteExt;
+
+const PONG_RSP: &[u8; 7] = b"+PONG\r\n";
+
+pub async fn ping(socket: &mut tokio::net::TcpStream) -> Result<(), Error> {
+    let mut response_buf = Vec::new();
+    response_buf.extend_from_slice(PONG_RSP);
+    SESSION_SEND.increment();
+    SESSION_SEND_BYTE.add(response_buf.len() as _);
+    TCP_SEND_BYTE.add(response_buf.len() as _);
+    if let Err(e) = socket.write_all(&response_buf).await {
+        SESSION_SEND_EX.increment();
+        return Err(e);
+    }
+    Ok(())
+}


### PR DESCRIPTION
When a customer was using stack exchange Redis C# SDK with `momento-proxy` they were unable to get going because SDK insists on doing some sort of check to make sure their TCP connection is established and can issue a command on the initialization of the client. The most minimal command I could add to make SDK happy was `PING` which doesn't seem like a bad thing to implement in proxy to ensure it's up. I tested this with StackExchange SDK and was able to get up and running with the following client config using this version of proxy. _Note the Excluded commands and the `Proxy = Proxy.Twemproxy` setting._
```csharp
ConfigurationOptions config = new ConfigurationOptions{
    EndPoints =
    {
        { "127.0.0.1", 6379 },
    },
    CommandMap = CommandMap.Create(new HashSet<string>
    { // EXCLUDE a few commands
        "INFO", "CONFIG", "CLUSTER",
        "ECHO", "CLIENT", "TIME",
        "EXISTS", "SUBSCRIBE"
    }, available: false),
    Proxy = Proxy.Twemproxy
};
```

This client configuration stopped the large majority of commands the startup of SDK was trying to do but it insisted on at least doing a `PING` and ignoring the startup failure caused SDK not to work when issuing subsequent get/sets.

I'm going to work with Brian for longer term if he wants me to contribute this down to main repo.